### PR TITLE
Fix UIViewController init & make it a Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "QRCoder",
+    platforms: [.iOS(.v12)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "QRCoder",
+            targets: ["QRCoder"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "QRCoder",
+            dependencies: [],
+            path: "Pod/Classes"),
+    ]
+)

--- a/Pod/Classes/QRCodeGenerator.swift
+++ b/Pod/Classes/QRCodeGenerator.swift
@@ -101,9 +101,9 @@ open class QRCodeGenerator : NSObject {
     private func createNonInterpolatedImageFromCIImage(image:CIImage, size:CGSize) -> QRImage? {
     
         #if (arch(i386) || arch(x86_64))
-        let contextOptions = [kCIContextUseSoftwareRenderer : false]
+        let contextOptions = [CIContextOption.useSoftwareRenderer : false]
         #else
-        let contextOptions = [kCIContextUseSoftwareRenderer : true]
+      let contextOptions = [CIContextOption.useSoftwareRenderer : true]
         #endif
     
         guard let cgImage = CIContext(options: contextOptions).createCGImage(image, from: image.extent) else { return nil }

--- a/Pod/Classes/QRCodeScannerViewController.swift
+++ b/Pod/Classes/QRCodeScannerViewController.swift
@@ -94,7 +94,7 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
     
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        captureSession.stopRunning()
+        stopRunning()
     }
     
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -154,15 +154,26 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
     public func startQRCodeScanningSession(){
         updateVideoOrientation(orientation: UIApplication.shared.statusBarOrientation)
         highlightView.frame = CGRect.zero
-        captureSession.startRunning()
+        startRunning()
     }
     
     /**
      Stops the scanning session
      */
     public func stopQRCodeScanningSession(){
-        captureSession.stopRunning()
+        stopRunning()
         highlightView.frame = CGRect.zero
+    }
+    
+    private func startRunning() {
+        DispatchQueue.global(qos: .background).async {
+	    	self.captureSession.startRunning()
+    	}
+    }
+    private func stopRunning() {
+        DispatchQueue.global(qos: .background).async {
+	    	self.captureSession.stopRunning()
+    	}        
     }
     
     //MARK: AVCaptureMetadataOutputObjectsDelegate
@@ -195,7 +206,7 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
         captureSession.stopRunning()
         
         if !showHighlightView && !self.processQRCodeContent(qrCodeContent: qrCode) {
-            self.captureSession.startRunning()
+            captureSession.startRunning()
         } else {
             DispatchQueue.main.sync {
                 self.highlightView.frame = highlightViewRect

--- a/Pod/Classes/QRCodeScannerViewController.swift
+++ b/Pod/Classes/QRCodeScannerViewController.swift
@@ -29,10 +29,18 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
     public var showHighlightView:Bool = true
     
     //MARK: Lifecycle
+
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+        setup()
+    }
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        
+        setup()
+    }
+
+    private func setup() {
         highlightView.autoresizingMask = [.flexibleTopMargin, .flexibleLeftMargin, .flexibleRightMargin, .flexibleBottomMargin]
         highlightView.layer.borderColor = UIColor.green.cgColor
         highlightView.layer.borderWidth = 3
@@ -76,7 +84,7 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
         videoPreviewLayer.frame = self.view.bounds
         videoPreviewLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
         view.layer.addSublayer(videoPreviewLayer)
-        view.bringSubview(toFront: highlightView)
+      view.bringSubviewToFront(highlightView)
     }
     
     override open func viewDidAppear(_ animated: Bool) {
@@ -136,7 +144,7 @@ open class QRCodeScannerViewController: UIViewController, AVCaptureMetadataOutpu
     * in subclasses to detect error. Do not dismiss controller immediately.
     * @param error The error object
     **/
-    public func didFailWithError(error: NSError) {
+    open func didFailWithError(error: NSError) {
         print("Error: \(error.description)")
     }
     


### PR DESCRIPTION
- [x] fix UIViewController init: the view controller couldn't be easily instantiated from code. By adding this empty `init()` it becomes much easier to do.
- [x] make it a Swift Package: no need for Cocoapods in 2022

Thanks for your library!